### PR TITLE
Feature mix in annotations: remove and rewrite MixIn

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -1261,11 +1261,14 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     }
     
     public static void addMixInAnnotations(Type target, Type mixinSource) {
+        JSON.removeMixInAnnotations(target);
         mixInsMapper.put(target, mixinSource);
     }
 
     public static void removeMixInAnnotations(Type target) {
         mixInsMapper.put(target, null);
+        ParserConfig.global.putDeserializer(target, null);
+        SerializeConfig.getGlobalInstance().put(target, null);
     }
 
     public static void clearMixInAnnotations() {

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -34,6 +34,7 @@ import com.alibaba.fastjson.parser.deserializer.FieldTypeResolver;
 import com.alibaba.fastjson.parser.deserializer.ParseProcess;
 import com.alibaba.fastjson.serializer.*;
 import com.alibaba.fastjson.util.IOUtils;
+import com.alibaba.fastjson.util.IdentityHashMap;
 import com.alibaba.fastjson.util.TypeUtils;
 
 /**
@@ -70,6 +71,9 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static String           DEFFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
     public static int              DEFAULT_PARSER_FEATURE;
     public static int              DEFAULT_GENERATE_FEATURE;
+
+    private static final IdentityHashMap<Type, Type> mixInsMapper = new IdentityHashMap<Type,Type>();
+    
     static {
         int features = 0;
         features |= Feature.AutoCloseSource.getMask();
@@ -1254,6 +1258,22 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
 
     public static <T> void handleResovleTask(DefaultJSONParser parser, T value) {
         parser.handleResovleTask(value);
+    }
+    
+    public static void addMixIn(Type target, Type mixinSource ) {
+        mixInsMapper.put(target, mixinSource);
+    }
+
+    public static void removeMixIn(Type target ) {
+        mixInsMapper.put(target, null);
+    }
+
+    public static void clearMixIn() {
+        mixInsMapper.clear();
+    }
+
+    public static Type getMixIn(Type target) {
+        return mixInsMapper.get(target);
     }
 
     public final static String VERSION = "1.2.60";

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -1260,19 +1260,19 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         parser.handleResovleTask(value);
     }
     
-    public static void addMixIn(Type target, Type mixinSource ) {
+    public static void addMixInAnnotations(Type target, Type mixinSource) {
         mixInsMapper.put(target, mixinSource);
     }
 
-    public static void removeMixIn(Type target ) {
+    public static void removeMixInAnnotations(Type target) {
         mixInsMapper.put(target, null);
     }
 
-    public static void clearMixIn() {
+    public static void clearMixInAnnotations() {
         mixInsMapper.clear();
     }
 
-    public static Type getMixIn(Type target) {
+    public static Type getMixInAnnotations(Type target) {
         return mixInsMapper.get(target);
     }
 

--- a/src/main/java/com/alibaba/fastjson/JSONObject.java
+++ b/src/main/java/com/alibaba/fastjson/JSONObject.java
@@ -416,7 +416,7 @@ public class JSONObject extends JSON implements Map<String, Object>, Cloneable, 
             }
 
             String name = null;
-            JSONField annotation = method.getAnnotation(JSONField.class);
+            JSONField annotation = TypeUtils.getAnnotation(method, JSONField.class);
             if (annotation != null) {
                 if (annotation.name().length() != 0) {
                     name = annotation.name();
@@ -448,7 +448,7 @@ public class JSONObject extends JSON implements Map<String, Object>, Cloneable, 
             }
 
             String name = null;
-            JSONField annotation = method.getAnnotation(JSONField.class);
+            JSONField annotation = TypeUtils.getAnnotation(method, JSONField.class);
             if (annotation != null) {
                 if (annotation.name().length() != 0) {
                     name = annotation.name();

--- a/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java
+++ b/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java
@@ -636,7 +636,7 @@ public class ParserConfig {
             }
 
             Class<?> deserClass = null;
-            JSONType jsonType = clazz.getAnnotation(JSONType.class);
+            JSONType jsonType = TypeUtils.getAnnotation( clazz, JSONType.class );
             if (jsonType != null) {
                 deserClass = jsonType.deserializer();
                 try {

--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/EnumDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/EnumDeserializer.java
@@ -10,6 +10,7 @@ import com.alibaba.fastjson.parser.DefaultJSONParser;
 import com.alibaba.fastjson.parser.Feature;
 import com.alibaba.fastjson.parser.JSONLexer;
 import com.alibaba.fastjson.parser.JSONToken;
+import com.alibaba.fastjson.util.TypeUtils;
 
 @SuppressWarnings("rawtypes")
 public class EnumDeserializer implements ObjectDeserializer {
@@ -32,7 +33,7 @@ public class EnumDeserializer implements ObjectDeserializer {
             JSONField jsonField = null;
             try {
                 Field field = enumClass.getField(name);
-                jsonField = field.getAnnotation(JSONField.class);
+                jsonField = TypeUtils.getAnnotation(field, JSONField.class);
                 if (jsonField != null) {
                     String jsonFieldName = jsonField.name();
                     if (jsonFieldName != null && jsonFieldName.length() > 0) {

--- a/src/main/java/com/alibaba/fastjson/util/ASMUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/ASMUtils.java
@@ -127,13 +127,13 @@ public class ASMUtils {
             types = method.getParameterTypes();
             name = method.getName();
             declaringClass = method.getDeclaringClass();
-            parameterAnnotations = method.getParameterAnnotations();
+            parameterAnnotations = TypeUtils.getParameterAnnotations(method);
         } else {
             Constructor<?> constructor = (Constructor<?>) methodOrCtor;
             types = constructor.getParameterTypes();
             declaringClass = constructor.getDeclaringClass();
             name = "<init>";
-            parameterAnnotations = constructor.getParameterAnnotations();
+            parameterAnnotations = TypeUtils.getParameterAnnotations(constructor);
         }
 
         if (types.length == 0) {

--- a/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
@@ -247,11 +247,11 @@ public class FieldInfo implements Comparable<FieldInfo> {
         
         T annotatition = null;
         if (method != null) {
-            annotatition = method.getAnnotation(annotationClass);
+            annotatition = TypeUtils.getAnnotation(method, annotationClass);
         }
         
         if (annotatition == null && field != null) {
-            annotatition = field.getAnnotation(annotationClass);
+            annotatition = TypeUtils.getAnnotation(field, annotationClass);
         }
         
         return annotatition;

--- a/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
@@ -135,7 +135,7 @@ public class JavaBeanInfo {
                     // skip
                 }
 
-                Annotation[][] paramAnnotationArrays = creatorConstructor.getParameterAnnotations();
+                Annotation[][] paramAnnotationArrays = TypeUtils.getParameterAnnotations(creatorConstructor);
                 for (int i = 0; i < creatorConstructorParameters.length && i < paramAnnotationArrays.length; ++i) {
                     Annotation[] paramAnnotations = paramAnnotationArrays[i];
                     JSONField fieldAnnotation = null;
@@ -288,7 +288,7 @@ public class JavaBeanInfo {
 
                 String[] lookupParameterNames = null;
                 if (types.length > 0) {
-                    Annotation[][] paramAnnotationArrays = creatorConstructor.getParameterAnnotations();
+                    Annotation[][] paramAnnotationArrays = TypeUtils.getParameterAnnotations(creatorConstructor);
                     for (int i = 0; i < types.length; ++i) {
                         Annotation[] paramAnnotations = paramAnnotationArrays[i];
                         JSONField fieldAnnotation = null;
@@ -348,7 +348,7 @@ public class JavaBeanInfo {
                 String[] lookupParameterNames = null;
                 Class<?>[] types = factoryMethod.getParameterTypes();
                 if (types.length > 0) {
-                    Annotation[][] paramAnnotationArrays = factoryMethod.getParameterAnnotations();
+                    Annotation[][] paramAnnotationArrays = TypeUtils.getParameterAnnotations(factoryMethod);
                     for (int i = 0; i < types.length; ++i) {
                         Annotation[] paramAnnotations = paramAnnotationArrays[i];
                         JSONField fieldAnnotation = null;
@@ -462,7 +462,7 @@ public class JavaBeanInfo {
 
                 if (paramNames != null
                         && types.length == paramNames.length) {
-                    Annotation[][] paramAnnotationArrays = creatorConstructor.getParameterAnnotations();
+                    Annotation[][] paramAnnotationArrays = TypeUtils.getParameterAnnotations(creatorConstructor);
                     for (int i = 0; i < types.length; ++i) {
                         Annotation[] paramAnnotations = paramAnnotationArrays[i];
                         String paramName = paramNames[i];
@@ -480,7 +480,7 @@ public class JavaBeanInfo {
                         Field field = TypeUtils.getField(clazz, paramName, declaredFields);
                         if (field != null) {
                             if (fieldAnnotation == null) {
-                                fieldAnnotation = field.getAnnotation(JSONField.class);
+                                fieldAnnotation = TypeUtils.getAnnotation(field, JSONField.class);
                             }
                         }
                         final int ordinal, serialzeFeatures, parserFeatures;
@@ -525,7 +525,7 @@ public class JavaBeanInfo {
         if (builderClass != null) {
             String withPrefix = null;
 
-            JSONPOJOBuilder builderAnno = builderClass.getAnnotation(JSONPOJOBuilder.class);
+            JSONPOJOBuilder builderAnno = TypeUtils.getAnnotation(builderClass, JSONPOJOBuilder.class);
             if (builderAnno != null) {
                 withPrefix = builderAnno.withPrefix();
             }
@@ -545,7 +545,7 @@ public class JavaBeanInfo {
 
                 int ordinal = 0, serialzeFeatures = 0, parserFeatures = 0;
 
-                JSONField annotation = method.getAnnotation(JSONField.class);
+                JSONField annotation = TypeUtils.getAnnotation(method, JSONField.class);
 
                 if (annotation == null) {
                     annotation = TypeUtils.getSuperMethodAnnotation(clazz, method);
@@ -598,7 +598,7 @@ public class JavaBeanInfo {
             }
 
             if (builderClass != null) {
-                JSONPOJOBuilder builderAnnotation = builderClass.getAnnotation(JSONPOJOBuilder.class);
+                JSONPOJOBuilder builderAnnotation = TypeUtils.getAnnotation(builderClass, JSONPOJOBuilder.class);
 
                 String buildMethodName = null;
                 if (builderAnnotation != null) {
@@ -659,7 +659,7 @@ public class JavaBeanInfo {
                 continue;
             }
 
-            JSONField annotation = method.getAnnotation(JSONField.class);
+            JSONField annotation = TypeUtils.getAnnotation(method, JSONField.class);
             if (annotation != null
                     && types.length == 2
                     && types[0] == String.class
@@ -731,7 +731,7 @@ public class JavaBeanInfo {
 
             JSONField fieldAnnotation = null;
             if (field != null) {
-                fieldAnnotation = field.getAnnotation(JSONField.class);
+                fieldAnnotation = TypeUtils.getAnnotation(field, JSONField.class);
 
                 if (fieldAnnotation != null) {
                     if (!fieldAnnotation.deserialize()) {
@@ -786,7 +786,7 @@ public class JavaBeanInfo {
                         ) {
                     String propertyName;
 
-                    JSONField annotation = method.getAnnotation(JSONField.class);
+                    JSONField annotation = TypeUtils.getAnnotation(method, JSONField.class);
                     if (annotation != null && annotation.deserialize()) {
                         continue;
                     }
@@ -798,7 +798,7 @@ public class JavaBeanInfo {
 
                         Field field = TypeUtils.getField(clazz, propertyName, declaredFields);
                         if (field != null) {
-                            JSONField fieldAnnotation = field.getAnnotation(JSONField.class);
+                            JSONField fieldAnnotation = TypeUtils.getAnnotation(field, JSONField.class);
                             if (fieldAnnotation != null && !fieldAnnotation.deserialize()) {
                                 continue;
                             }
@@ -868,7 +868,7 @@ public class JavaBeanInfo {
             int ordinal = 0, serialzeFeatures = 0, parserFeatures = 0;
             String propertyName = field.getName();
 
-            JSONField fieldAnnotation = field.getAnnotation(JSONField.class);
+            JSONField fieldAnnotation = TypeUtils.getAnnotation(field, JSONField.class);
 
             if (fieldAnnotation != null) {
                 if (!fieldAnnotation.deserialize()) {
@@ -942,7 +942,7 @@ public class JavaBeanInfo {
         }
 
         for (Constructor constructor : constructors) {
-            Annotation[][] paramAnnotationArrays = constructor.getParameterAnnotations();
+            Annotation[][] paramAnnotationArrays = TypeUtils.getParameterAnnotations(constructor);
             if (paramAnnotationArrays.length == 0) {
                 continue;
             }
@@ -989,7 +989,7 @@ public class JavaBeanInfo {
                 continue;
             }
 
-            JSONCreator annotation = method.getAnnotation(JSONCreator.class);
+            JSONCreator annotation = TypeUtils.getAnnotation(method, JSONCreator.class);
             if (annotation != null) {
                 if (factoryMethod != null) {
                     throw new JSONException("multi-JSONCreator");

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -133,7 +133,7 @@ public class TypeUtils{
             return false;
         }
 
-        Annotation annotation = clazz.getAnnotation(class_XmlAccessorType);
+        Annotation annotation = TypeUtils.getAnnotation(clazz, class_XmlAccessorType);
         if (annotation == null) {
             return false;
         }
@@ -189,7 +189,7 @@ public class TypeUtils{
             return null;
         }
 
-        return  clazz.getAnnotation(class_XmlAccessorType);
+        return  TypeUtils.getAnnotation(clazz, class_XmlAccessorType);
     }
 
 //
@@ -1767,7 +1767,7 @@ public class TypeUtils{
              *  如果在属性或者方法上存在JSONField注解，并且定制了name属性，不以类上的propertyNamingStrategy设置为准，以此字段的JSONField的name定制为准。
              */
             Boolean fieldAnnotationAndNameExists = false;
-            JSONField annotation = method.getAnnotation(JSONField.class);
+            JSONField annotation = TypeUtils.getAnnotation(method, JSONField.class);
             if(annotation == null){
                 annotation = getSuperMethodAnnotation(clazz, method);
             }
@@ -1776,7 +1776,7 @@ public class TypeUtils{
                     constructors = clazz.getDeclaredConstructors();
                     Constructor creatorConstructor = TypeUtils.getKoltinConstructor(constructors);
                     if(creatorConstructor != null){
-                        paramAnnotationArrays = creatorConstructor.getParameterAnnotations();
+                        paramAnnotationArrays = TypeUtils.getParameterAnnotations(creatorConstructor);
                         paramNames = TypeUtils.getKoltinConstructorParameters(clazz);
                         if(paramNames != null){
                             String[] paramNames_sorted = new String[paramNames.length];
@@ -1817,7 +1817,7 @@ public class TypeUtils{
                         if(annotation == null){
                             Field field = ParserConfig.getFieldFromCache(propertyName, fieldCacheMap);
                             if(field != null){
-                                annotation = field.getAnnotation(JSONField.class);
+                                annotation = TypeUtils.getAnnotation(field, JSONField.class);
                             }
                         }
                     }
@@ -1892,7 +1892,7 @@ public class TypeUtils{
                 }
                 JSONField fieldAnnotation = null;
                 if(field != null){
-                    fieldAnnotation = field.getAnnotation(JSONField.class);
+                    fieldAnnotation = TypeUtils.getAnnotation(field, JSONField.class);
                     if(fieldAnnotation != null){
                         if(!fieldAnnotation.serialize()){
                             continue;
@@ -1962,7 +1962,7 @@ public class TypeUtils{
                 }
                 JSONField fieldAnnotation = null;
                 if(field != null){
-                    fieldAnnotation = field.getAnnotation(JSONField.class);
+                    fieldAnnotation = TypeUtils.getAnnotation(field, JSONField.class);
                     if(fieldAnnotation != null){
                         if(!fieldAnnotation.serialize()){
                             continue;
@@ -2051,7 +2051,7 @@ public class TypeUtils{
             if(Modifier.isStatic(field.getModifiers())){
                 continue;
             }
-            JSONField fieldAnnotation = field.getAnnotation(JSONField.class);
+            JSONField fieldAnnotation = TypeUtils.getAnnotation(field, JSONField.class);
             int ordinal = 0, serialzeFeatures = 0, parserFeatures = 0;
             String propertyName = field.getName();
             String label = null;
@@ -2120,7 +2120,7 @@ public class TypeUtils{
                     if(!match){
                         continue;
                     }
-                    JSONField annotation = interfaceMethod.getAnnotation(JSONField.class);
+                    JSONField annotation = TypeUtils.getAnnotation(interfaceMethod, JSONField.class);
                     if(annotation != null){
                         return annotation;
                     }
@@ -2151,7 +2151,7 @@ public class TypeUtils{
                 if(!match){
                     continue;
                 }
-                JSONField annotation = interfaceMethod.getAnnotation(JSONField.class);
+                JSONField annotation = TypeUtils.getAnnotation(interfaceMethod, JSONField.class);
                 if(annotation != null){
                     return annotation;
                 }
@@ -2554,7 +2554,7 @@ public class TypeUtils{
             }
         }
         if(transientClass != null){
-            Annotation annotation = method.getAnnotation(transientClass);
+            Annotation annotation = TypeUtils.getAnnotation(method, transientClass);
             return annotation != null;
         }
         return false;
@@ -2900,21 +2900,196 @@ public class TypeUtils{
         return ignores != null && Arrays.binarySearch(ignores, methodName) >= 0;
     }
 
-    public static <A extends Annotation> A getAnnotation(Class<?> clazz, Class<A> annotationClass){
-        A a = clazz.getAnnotation(annotationClass);
-        if (a != null){
-            return a;
+    public static <A extends Annotation> A getAnnotation(Class<?> targetClass, Class<A> annotationClass){
+        A targetAnnotation = targetClass.getAnnotation(annotationClass);
+
+        Class<?> mixInClass = null;
+        Type type = JSON.getMixIn(targetClass);
+        if (type instanceof Class<?>) {
+            mixInClass = (Class<?>) type;
         }
 
-        if(clazz.getAnnotations().length > 0){
-            for(Annotation annotation : clazz.getAnnotations()){
-                a = annotation.annotationType().getAnnotation(annotationClass);
-                if(a != null){
-                    return a;
+        if(mixInClass != null) {
+            A mixInAnnotation = mixInClass.getAnnotation(annotationClass);
+            if(mixInAnnotation == null && mixInClass.getAnnotations().length > 0){
+                for(Annotation annotation : mixInClass.getAnnotations()){
+                    mixInAnnotation = annotation.annotationType().getAnnotation(annotationClass);
+                    if(mixInAnnotation != null){
+                        break;
+                    }
+                }
+            }
+            if (mixInAnnotation != null) {
+                return mixInAnnotation;
+            }
+        }
+
+        if(targetAnnotation == null && targetClass.getAnnotations().length > 0){
+            for(Annotation annotation : targetClass.getAnnotations()){
+                targetAnnotation = annotation.annotationType().getAnnotation(annotationClass);
+                if(targetAnnotation != null){
+                    break;
                 }
             }
         }
-        return null;
+        return targetAnnotation;
+    }
+
+    public static <A extends Annotation> A getAnnotation(Field field, Class<A> annotationClass){
+        A targetAnnotation = field.getAnnotation(annotationClass);
+
+        Class<?> clazz = field.getDeclaringClass();
+        A mixInAnnotation;
+        Class<?> mixInClass = null;
+        Type type = JSON.getMixIn(clazz);
+        if (type instanceof Class<?>) {
+            mixInClass = (Class<?>) type;
+        }
+
+        if (mixInClass != null) {
+            Field mixInField = null;
+            String fieldName = field.getName();
+            // 递归从MixIn类的父类中查找注解（如果有父类的话）
+            for (Class<?> currClass = mixInClass; currClass != null && currClass != Object.class;
+                 currClass = currClass.getSuperclass()) {
+                try {
+                    mixInField = currClass.getDeclaredField(fieldName);
+                    break;
+                } catch (NoSuchFieldException e) {
+                    // skip
+                }
+            }
+            if (mixInField == null) {
+                return targetAnnotation;
+            }
+            mixInAnnotation = mixInField.getAnnotation(annotationClass);
+            if (mixInAnnotation != null) {
+                return mixInAnnotation;
+            }
+        }
+        return targetAnnotation;
+    }
+
+    public static <A extends Annotation> A getAnnotation(Method method, Class<A> annotationClass){
+        A targetAnnotation = method.getAnnotation(annotationClass);
+
+        Class<?> clazz = method.getDeclaringClass();
+        A mixInAnnotation;
+        Class<?> mixInClass = null;
+        Type type = JSON.getMixIn(clazz);
+        if (type instanceof Class<?>) {
+            mixInClass = (Class<?>) type;
+        }
+
+        if (mixInClass != null) {
+            Method mixInMethod = null;
+            String methodName = method.getName();
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            // 递归从MixIn类的父类中查找注解（如果有父类的话）
+            for (Class<?> currClass = mixInClass; currClass != null && currClass != Object.class;
+                 currClass = currClass.getSuperclass()) {
+                try {
+                    mixInMethod = currClass.getDeclaredMethod(methodName, parameterTypes);
+                    break;
+                } catch (NoSuchMethodException e) {
+                    // skip
+                }
+            }
+            if (mixInMethod == null) {
+                return targetAnnotation;
+            }
+            mixInAnnotation = mixInMethod.getAnnotation(annotationClass);
+            if (mixInAnnotation != null) {
+                return mixInAnnotation;
+            }
+        }
+        return targetAnnotation;
+    }
+
+    public static Annotation[][] getParameterAnnotations(Method method){
+        Annotation[][] targetAnnotations = method.getParameterAnnotations();
+
+        Class<?> clazz = method.getDeclaringClass();
+        Annotation[][] mixInAnnotations;
+        Class<?> mixInClass = null;
+        Type type = JSON.getMixIn(clazz);
+        if (type instanceof Class<?>) {
+            mixInClass = (Class<?>) type;
+        }
+
+        if (mixInClass != null) {
+            Method mixInMethod = null;
+            String methodName = method.getName();
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            // 递归从MixIn类的父类中查找注解（如果有父类的话）
+            for (Class<?> currClass = mixInClass; currClass != null && currClass != Object.class;
+                 currClass = currClass.getSuperclass()) {
+                try {
+                    mixInMethod = currClass.getDeclaredMethod(methodName, parameterTypes);
+                    break;
+                } catch (NoSuchMethodException e) {
+                    continue;
+                }
+            }
+            if (mixInMethod == null) {
+                return targetAnnotations;
+            }
+            mixInAnnotations = mixInMethod.getParameterAnnotations();
+            if (mixInAnnotations != null) {
+                return mixInAnnotations;
+            }
+        }
+        return targetAnnotations;
+    }
+
+    public static Annotation[][] getParameterAnnotations(Constructor constructor){
+        Annotation[][] targetAnnotations = constructor.getParameterAnnotations();
+
+        Class<?> clazz = constructor.getDeclaringClass();
+        Annotation[][] mixInAnnotations;
+        Class<?> mixInClass = null;
+        Type type = JSON.getMixIn(clazz);
+        if (type instanceof Class<?>) {
+            mixInClass = (Class<?>) type;
+        }
+
+        if (mixInClass != null) {
+            Constructor mixInConstructor = null;
+            Class<?>[] parameterTypes = constructor.getParameterTypes();
+            // 构建参数列表，因为内部类的构造函数需要传入外部类的引用
+            List<Class<?>> enclosingClasses = new ArrayList<Class<?>>(2);
+            for (Class<?> enclosingClass = mixInClass.getEnclosingClass(); enclosingClass != null; enclosingClass = enclosingClass.getEnclosingClass()) {
+                enclosingClasses.add(enclosingClass);
+            }
+            int level = enclosingClasses.size();
+            // 递归从MixIn类的父类中查找注解（如果有父类的话）
+            for (Class<?> currClass = mixInClass; currClass != null && currClass != Object.class;
+                 currClass = currClass.getSuperclass()) {
+                try {
+                    if (level != 0) {
+                        Class<?>[] outerClassAndParameterTypes = new Class[level + parameterTypes.length];
+                        System.arraycopy(parameterTypes, 0, outerClassAndParameterTypes, level, parameterTypes.length);
+                        for (int i = level; i > 0 ; i--) {
+                            outerClassAndParameterTypes[i - 1] = enclosingClasses.get(i - 1);
+                        }
+                        mixInConstructor = mixInClass.getDeclaredConstructor(outerClassAndParameterTypes);
+                    } else {
+                        mixInConstructor = mixInClass.getDeclaredConstructor(parameterTypes);
+                    }
+                    break;
+                } catch (NoSuchMethodException e) {
+                    level--;
+                }
+            }
+            if (mixInConstructor == null) {
+                return targetAnnotations;
+            }
+            mixInAnnotations = mixInConstructor.getParameterAnnotations();
+            if (mixInAnnotations != null) {
+                return mixInAnnotations;
+            }
+        }
+        return targetAnnotations;
     }
 
     public static boolean isJacksonCreator(Method method) {

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -2904,7 +2904,7 @@ public class TypeUtils{
         A targetAnnotation = targetClass.getAnnotation(annotationClass);
 
         Class<?> mixInClass = null;
-        Type type = JSON.getMixIn(targetClass);
+        Type type = JSON.getMixInAnnotations(targetClass);
         if (type instanceof Class<?>) {
             mixInClass = (Class<?>) type;
         }
@@ -2941,7 +2941,7 @@ public class TypeUtils{
         Class<?> clazz = field.getDeclaringClass();
         A mixInAnnotation;
         Class<?> mixInClass = null;
-        Type type = JSON.getMixIn(clazz);
+        Type type = JSON.getMixInAnnotations(clazz);
         if (type instanceof Class<?>) {
             mixInClass = (Class<?>) type;
         }
@@ -2976,7 +2976,7 @@ public class TypeUtils{
         Class<?> clazz = method.getDeclaringClass();
         A mixInAnnotation;
         Class<?> mixInClass = null;
-        Type type = JSON.getMixIn(clazz);
+        Type type = JSON.getMixInAnnotations(clazz);
         if (type instanceof Class<?>) {
             mixInClass = (Class<?>) type;
         }
@@ -3012,7 +3012,7 @@ public class TypeUtils{
         Class<?> clazz = method.getDeclaringClass();
         Annotation[][] mixInAnnotations;
         Class<?> mixInClass = null;
-        Type type = JSON.getMixIn(clazz);
+        Type type = JSON.getMixInAnnotations(clazz);
         if (type instanceof Class<?>) {
             mixInClass = (Class<?>) type;
         }
@@ -3048,7 +3048,7 @@ public class TypeUtils{
         Class<?> clazz = constructor.getDeclaringClass();
         Annotation[][] mixInAnnotations;
         Class<?> mixInClass = null;
-        Type type = JSON.getMixIn(clazz);
+        Type type = JSON.getMixInAnnotations(clazz);
         if (type instanceof Class<?>) {
             mixInClass = (Class<?>) type;
         }

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinDeserForClassTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinDeserForClassTest.java
@@ -43,10 +43,10 @@ public class MixinDeserForClassTest extends TestCase {
     }
 
     public void test_2() throws Exception {
-        JSON.addMixIn(BaseClass.class, Mixin.class);
+        JSON.addMixInAnnotations(BaseClass.class, Mixin.class);
         BaseClass base = JSON.parseObject( "{\"a\":\"132\"}", BaseClass.class );
         Assert.assertEquals( "XXX132", base.a );
-        JSON.removeMixIn(BaseClass.class);
+        JSON.removeMixInAnnotations(BaseClass.class);
     }
 
 }

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinDeserForClassTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinDeserForClassTest.java
@@ -1,0 +1,52 @@
+package com.alibaba.json.bvt.mixins;
+
+import org.junit.Assert;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+
+import junit.framework.TestCase;
+
+public class MixinDeserForClassTest extends TestCase {
+    static class BaseClass {
+        @JSONField( deserialize = true )
+        public String a;
+
+        @JSONField( deserialize = false, name = "a" )
+        public void setA( String v ) {
+            a = "XXX" + v;
+        }
+    }
+
+    static class BaseClass1 {
+        @JSONField( deserialize = false )
+        public String a;
+
+        @JSONField( deserialize = true, name = "a" )
+        public void setA( String v ) {
+            a = "XXX" + v;
+        }
+    }
+
+    static class Mixin {
+        @JSONField( deserialize = false )
+        public String a;
+
+        @JSONField( deserialize = true, name = "a" )
+        public void setA( String v ) {
+        }
+    }
+
+    public void test_1() throws Exception {
+        BaseClass1 base = JSON.parseObject( "{\"a\":\"132\"}", BaseClass1.class );
+        Assert.assertEquals( "XXX132", base.a );
+    }
+
+    public void test_2() throws Exception {
+        JSON.addMixIn(BaseClass.class, Mixin.class);
+        BaseClass base = JSON.parseObject( "{\"a\":\"132\"}", BaseClass.class );
+        Assert.assertEquals( "XXX132", base.a );
+        JSON.removeMixIn(BaseClass.class);
+    }
+
+}

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinDeserForClassTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinDeserForClassTest.java
@@ -28,12 +28,22 @@ public class MixinDeserForClassTest extends TestCase {
         }
     }
 
-    static class Mixin {
+    class Mixin1 {
         @JSONField( deserialize = false )
         public String a;
 
         @JSONField( deserialize = true, name = "a" )
         public void setA( String v ) {
+        }
+    }
+
+    class Mixin2 {
+        @JSONField( deserialize = false )
+        public String a;
+
+        @JSONField( deserialize = true, name = "a2" )
+        public void setA( String v ) {
+            a = "a2 " + v;
         }
     }
 
@@ -43,9 +53,35 @@ public class MixinDeserForClassTest extends TestCase {
     }
 
     public void test_2() throws Exception {
-        JSON.addMixInAnnotations(BaseClass.class, Mixin.class);
+        JSON.addMixInAnnotations(BaseClass.class, Mixin1.class);
         BaseClass base = JSON.parseObject( "{\"a\":\"132\"}", BaseClass.class );
         Assert.assertEquals( "XXX132", base.a );
+        JSON.removeMixInAnnotations(BaseClass.class);
+    }
+
+    public void test_3() throws Exception {
+        JSON.addMixInAnnotations(BaseClass.class, Mixin1.class);
+        BaseClass base = JSON.parseObject( "{\"a\":\"132\"}", BaseClass.class );
+        Assert.assertEquals( "XXX132", base.a );
+        JSON.removeMixInAnnotations(BaseClass.class);
+
+        JSON.addMixInAnnotations(BaseClass.class, Mixin2.class);
+        base = JSON.parseObject( "{\"a2\":\"143\"}", BaseClass.class );
+        Assert.assertEquals( "XXX143", base.a );
+        JSON.removeMixInAnnotations(BaseClass.class);
+
+        base = JSON.parseObject( "{\"a\":\"132\", \"a2\":\"143\"}", BaseClass.class );
+        Assert.assertEquals( "132", base.a );
+    }
+
+    public void test_4() throws Exception {
+        JSON.addMixInAnnotations(BaseClass.class, Mixin1.class);
+        BaseClass base = JSON.parseObject( "{\"a\":\"132\"}", BaseClass.class );
+        Assert.assertEquals( "XXX132", base.a );
+
+        JSON.addMixInAnnotations(BaseClass.class, Mixin2.class);
+        base = JSON.parseObject( "{\"a2\":\"143\"}", BaseClass.class );
+        Assert.assertEquals( "XXX143", base.a );
         JSON.removeMixInAnnotations(BaseClass.class);
     }
 

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinDeserForMethodsTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinDeserForMethodsTest.java
@@ -1,0 +1,65 @@
+package com.alibaba.json.bvt.mixins;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONCreator;
+import com.alibaba.fastjson.annotation.JSONField;
+
+import junit.framework.TestCase;
+
+public class MixinDeserForMethodsTest extends TestCase {
+
+    static class BaseClass {
+        protected HashMap<String, Object> values = new HashMap<String, Object>();
+
+        @JSONCreator
+        public BaseClass( @JSONField( name = "name" ) String name,@JSONField( name = "age" ) String age,
+                @JSONField( name = "student" ) Object student ) {
+            values.put( "name", name );
+            values.put( "age", age );
+            values.put( "student", student );
+        }
+    }
+
+    static class BaseClass2 {
+        protected HashMap<String, Object> values = new HashMap<String, Object>();
+
+        public BaseClass2( String name,String age,Object student ) {
+            values.put( "name", name );
+            values.put( "age", age );
+            values.put( "student", student );
+        }
+    }
+
+    class MixIn {
+        @JSONCreator
+        MixIn( @JSONField( name = "name" ) String name,@JSONField( name = "age" ) String age,
+                @JSONField( name = "student" ) Object student ) {
+        };
+    }
+
+    public void test_0() throws Exception {
+        BaseClass result = JSON.parseObject( "{ \"name\" : \"David\", \"age\" : 13, \"student\" : true }",
+                BaseClass.class );
+        Assert.assertNotNull( result );
+        Assert.assertEquals( 3, result.values.size() );
+        Assert.assertEquals( "David", result.values.get( "name" ) );
+        Assert.assertEquals( "13", result.values.get( "age" ) );
+        Assert.assertEquals( Boolean.TRUE, result.values.get( "student" ) );
+    }
+
+    public void test_1() throws Exception {
+        JSON.addMixIn(BaseClass2.class, MixIn.class);
+        BaseClass2 result = JSON.parseObject( "{ \"name\" : \"David\", \"age\" : 13, \"student\" : true }",
+                BaseClass2.class );
+        Assert.assertNotNull( result );
+        Assert.assertEquals( 3, result.values.size() );
+        Assert.assertEquals( "David", result.values.get( "name" ) );
+        Assert.assertEquals( "13", result.values.get( "age" ) );
+        Assert.assertEquals( Boolean.TRUE, result.values.get( "student" ) );
+        JSON.removeMixIn(BaseClass2.class);
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinDeserForMethodsTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinDeserForMethodsTest.java
@@ -52,7 +52,7 @@ public class MixinDeserForMethodsTest extends TestCase {
     }
 
     public void test_1() throws Exception {
-        JSON.addMixIn(BaseClass2.class, MixIn.class);
+        JSON.addMixInAnnotations(BaseClass2.class, MixIn.class);
         BaseClass2 result = JSON.parseObject( "{ \"name\" : \"David\", \"age\" : 13, \"student\" : true }",
                 BaseClass2.class );
         Assert.assertNotNull( result );
@@ -60,6 +60,6 @@ public class MixinDeserForMethodsTest extends TestCase {
         Assert.assertEquals( "David", result.values.get( "name" ) );
         Assert.assertEquals( "13", result.values.get( "age" ) );
         Assert.assertEquals( Boolean.TRUE, result.values.get( "student" ) );
-        JSON.removeMixIn(BaseClass2.class);
+        JSON.removeMixInAnnotations(BaseClass2.class);
     }
 }

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinInheritanceTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinInheritanceTest.java
@@ -41,7 +41,7 @@ public class MixinInheritanceTest
     }
 
     public void test_field() throws Exception {
-        JSON.addMixIn(Beano.class, BeanoMixinSub.class);
+        JSON.addMixInAnnotations(Beano.class, BeanoMixinSub.class);
         String str = JSON.toJSONString(new Beano());
         JSONObject result = JSONObject.parseObject(str);
         assertEquals(2, result.size());
@@ -49,16 +49,16 @@ public class MixinInheritanceTest
                 || !result.containsKey("name")) {
             fail("Should have both 'id' and 'name', but content = " + result);
         }
-        JSON.removeMixIn(Beano.class);
+        JSON.removeMixInAnnotations(Beano.class);
     }
 
     public void test_method() throws Exception {
-        JSON.addMixIn(Beano2.class, BeanoMixinSub2.class);
+        JSON.addMixInAnnotations(Beano2.class, BeanoMixinSub2.class);
         String str = JSON.toJSONString(new Beano2());
         JSONObject result = JSONObject.parseObject(str);
         assertEquals(2, result.size());
         assertTrue(result.containsKey("id"));
         assertTrue(result.containsKey("name"));
-        JSON.removeMixIn(Beano2.class);
+        JSON.removeMixInAnnotations(Beano2.class);
     }
 }

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinInheritanceTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinInheritanceTest.java
@@ -1,0 +1,64 @@
+package com.alibaba.json.bvt.mixins;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+
+public class MixinInheritanceTest
+    extends TestCase
+{
+    static class Beano {
+        public int ido = 42;
+        public String nameo = "Bob";
+    }
+
+    static class BeanoMixinSuper {
+        @JSONField(name = "name")
+        public String nameo;
+    }
+
+    static class BeanoMixinSub extends BeanoMixinSuper {
+        @JSONField(name = "id")
+        public int ido;
+    }
+
+    static class Beano2 {
+        public int getIdo() { return 13; }
+        public String getNameo() { return "Bill"; }
+    }
+
+    static abstract class BeanoMixinSuper2 extends Beano2 {
+        @Override
+        @JSONField(name = "name")
+        public abstract String getNameo();
+    }
+
+    static abstract class BeanoMixinSub2 extends BeanoMixinSuper2 {
+        @Override
+        @JSONField(name = "id")
+        public abstract int getIdo();
+    }
+
+    public void test_field() throws Exception {
+        JSON.addMixIn(Beano.class, BeanoMixinSub.class);
+        String str = JSON.toJSONString(new Beano());
+        JSONObject result = JSONObject.parseObject(str);
+        assertEquals(2, result.size());
+        if (!result.containsKey("id")
+                || !result.containsKey("name")) {
+            fail("Should have both 'id' and 'name', but content = " + result);
+        }
+        JSON.removeMixIn(Beano.class);
+    }
+
+    public void test_method() throws Exception {
+        JSON.addMixIn(Beano2.class, BeanoMixinSub2.class);
+        String str = JSON.toJSONString(new Beano2());
+        JSONObject result = JSONObject.parseObject(str);
+        assertEquals(2, result.size());
+        assertTrue(result.containsKey("id"));
+        assertTrue(result.containsKey("name"));
+        JSON.removeMixIn(Beano2.class);
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinMergingTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinMergingTest.java
@@ -1,0 +1,35 @@
+package com.alibaba.json.bvt.mixins;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+
+public class MixinMergingTest extends TestCase
+{
+    public interface Contact {
+        String getCity();
+    }
+
+    static class ContactImpl implements Contact {
+        @Override
+        public String getCity() { return "Seattle"; }
+    }
+
+    static class ContactMixin implements Contact {
+        @Override
+        @JSONField
+        public String getCity() { return null; }
+    }
+
+    public interface Person extends Contact {}
+
+    static class PersonImpl extends ContactImpl implements Person {}
+
+    static class PersonMixin extends ContactMixin implements Person {}
+
+    public void test() throws Exception {
+        JSON.addMixIn(Person.class, PersonMixin.class);
+        assertEquals("{\"city\":\"Seattle\"}", JSON.toJSONString(new PersonImpl()));
+        JSON.removeMixIn(Person.class);
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinMergingTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinMergingTest.java
@@ -28,8 +28,8 @@ public class MixinMergingTest extends TestCase
     static class PersonMixin extends ContactMixin implements Person {}
 
     public void test() throws Exception {
-        JSON.addMixIn(Person.class, PersonMixin.class);
+        JSON.addMixInAnnotations(Person.class, PersonMixin.class);
         assertEquals("{\"city\":\"Seattle\"}", JSON.toJSONString(new PersonImpl()));
-        JSON.removeMixIn(Person.class);
+        JSON.removeMixInAnnotations(Person.class);
     }
 }

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinSerForFieldsTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinSerForFieldsTest.java
@@ -1,0 +1,37 @@
+package com.alibaba.json.bvt.mixins;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.annotation.JSONField;
+
+import junit.framework.TestCase;
+
+public class MixinSerForFieldsTest extends TestCase {
+    static class BeanClass {
+        public String a;
+        public String b;
+
+        public BeanClass(String a, String b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    abstract class MixIn {
+        @JSONField(serialize = false)
+        public String a;
+        @JSONField(name = "banana")
+        public String b;
+    }
+
+    public void test() throws Exception{
+        BeanClass bean = new BeanClass("1", "2");
+
+        JSON.addMixIn(BeanClass.class, MixIn.class);
+        String jsonString = JSON.toJSONString(bean);
+        JSONObject result = JSON.parseObject(jsonString);
+        assertEquals(1, result.size());
+        assertEquals("2", result.get("banana"));
+        JSON.removeMixIn(BeanClass.class);
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinSerForFieldsTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinSerForFieldsTest.java
@@ -27,11 +27,11 @@ public class MixinSerForFieldsTest extends TestCase {
     public void test() throws Exception{
         BeanClass bean = new BeanClass("1", "2");
 
-        JSON.addMixIn(BeanClass.class, MixIn.class);
+        JSON.addMixInAnnotations(BeanClass.class, MixIn.class);
         String jsonString = JSON.toJSONString(bean);
         JSONObject result = JSON.parseObject(jsonString);
         assertEquals(1, result.size());
         assertEquals("2", result.get("banana"));
-        JSON.removeMixIn(BeanClass.class);
+        JSON.removeMixInAnnotations(BeanClass.class);
     }
 }

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinSerForMethodsTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinSerForMethodsTest.java
@@ -1,0 +1,79 @@
+package com.alibaba.json.bvt.mixins;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.annotation.JSONField;
+
+import junit.framework.TestCase;
+
+public class MixinSerForMethodsTest extends TestCase {
+
+    @SuppressWarnings( "unused" )
+    static class BaseClass {
+        private String a;
+        private String b;
+
+        protected BaseClass() {
+        }
+
+        public BaseClass( String a,String b ) {
+            this.a = a;
+            this.b = b;
+        }
+
+        @JSONField( name = "b" )
+        public String takeB() {
+            return b;
+        }
+    }
+
+    static class BaseClass2 {
+        private String a;
+        private String b;
+
+        protected BaseClass2() {
+        }
+
+        public BaseClass2( String a,String b ) {
+            this.a = a;
+            this.b = b;
+        }
+
+        @JSONField( name = "b" )
+        public String takeB() {
+            return b;
+        }
+
+        @JSONField( name = "a" )
+        public String takeA() {
+            return a;
+        }
+    }
+
+    abstract static class MixIn {
+        String a;
+
+        @JSONField( name = "b2" )
+        public abstract String takeB();
+
+        abstract String takeA();
+    }
+
+    public void test() throws Exception{
+        BaseClass bean = new BaseClass( "a1", "b2" );
+
+        String jsonString = JSON.toJSONString( bean );
+        JSONObject result = JSON.parseObject( jsonString );
+        assertEquals( 1, result.size() );
+        assertEquals( "b2", result.get( "b" ) );
+
+        BaseClass2 bean2 = new BaseClass2( "a1", "b2" );
+        JSON.addMixIn( BaseClass2.class, MixIn.class );
+        jsonString = JSON.toJSONString( bean2 );
+        result = JSON.parseObject( jsonString );
+        assertEquals( 2, result.size() );
+        assertEquals( "b2", result.get( "b2" ) );
+        assertEquals( "a1", result.get( "a" ) );
+        JSON.removeMixIn( BaseClass.class );
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/mixins/MixinSerForMethodsTest.java
+++ b/src/test/java/com/alibaba/json/bvt/mixins/MixinSerForMethodsTest.java
@@ -68,12 +68,12 @@ public class MixinSerForMethodsTest extends TestCase {
         assertEquals( "b2", result.get( "b" ) );
 
         BaseClass2 bean2 = new BaseClass2( "a1", "b2" );
-        JSON.addMixIn( BaseClass2.class, MixIn.class );
+        JSON.addMixInAnnotations( BaseClass2.class, MixIn.class );
         jsonString = JSON.toJSONString( bean2 );
         result = JSON.parseObject( jsonString );
         assertEquals( 2, result.size() );
         assertEquals( "b2", result.get( "b2" ) );
         assertEquals( "a1", result.get( "a" ) );
-        JSON.removeMixIn( BaseClass.class );
+        JSON.removeMixInAnnotations( BaseClass.class );
     }
 }


### PR DESCRIPTION
Add remove and rewrite MixIn functionality when we using default ParserConfig.global and SerializeConfig.global.