### PR TITLE
2819解决方案

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/issue_2800/Issue2819.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2800/Issue2819.java
@@ -1,0 +1,20 @@
+package com.alibaba.json.bvt.issue_2800;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+
+import jersey.repackaged.com.google.common.collect.Lists;
+import junit.framework.TestCase;
+
+public class Issue2819 extends TestCase {
+    public void test_for_issue() throws Exception {
+        BigInteger bint = new BigInteger("231548942313154123");
+        List<Object> list = Lists.newArrayList();
+        list.add(12345678912312121L);
+        list.add(bint);
+        System.out.println(JSON.toJSONString(list, SerializerFeature.BrowserCompatible));
+    }
+}


### PR DESCRIPTION
可以通过SerializerFeature.BrowserCompatible特性来给Long或者BigInteger序列化后加上引号
![image](https://user-images.githubusercontent.com/41422726/67063903-0190c300-f19b-11e9-94d7-2bea1bfa297d.png)


